### PR TITLE
feat: support reflect conversion from array kind

### DIFF
--- a/go2ts.go
+++ b/go2ts.go
@@ -134,7 +134,7 @@ func (c *Converter) AddParamNames(customParamNames map[reflect.Type]string) {
 //
 // Interfaces are converted to any.
 //
-// struct methods are NOT converted, but Converter.ConfigureFunc can be 
+// struct methods are NOT converted, but Converter.ConfigureFunc can be
 // used to create method declarations.
 func (c *Converter) Convert(t reflect.Type) (ts string) {
 	ts, ok := c.types[t]
@@ -162,7 +162,7 @@ func (c *Converter) Convert(t reflect.Type) (ts string) {
 		ts = c.convertFunc(t)
 	} else if kind == reflect.Struct {
 		ts = c.convertStruct(t)
-	} else if kind == reflect.Slice {
+	} else if kind == reflect.Slice || kind == reflect.Array {
 		ts = fmt.Sprintf("Array<%s>", c.convert(t.Elem()))
 	} else if kind == reflect.Map {
 		ts = fmt.Sprintf("{ [k: string]: %s }", c.convert(t.Elem()))

--- a/go2ts_test.go
+++ b/go2ts_test.go
@@ -79,6 +79,11 @@ func TestSlices(t *testing.T) {
 	expect(t, c.Convert(typ([]*User{})), "Array<{ Name: string }>")
 }
 
+func TestArrays(t *testing.T) {
+	c := NewConverter()
+	expect(t, c.Convert(typ([2]string{"first", "second"})), "Array<string>")
+}
+
 func TestMaps(t *testing.T) {
 	c := NewConverter()
 	expect(t, c.Convert(typ(map[string]int{})), "{ [k: string]: number }")


### PR DESCRIPTION
This PR adds support for reflect conversion from array kind.

I was trying to update https://github.com/filecoin-shipyard/js-lotus-client-schema to the latest lotus version and I am getting a panic error from this tool:

```
panic: unhandled type: uuid.UUID (array)
```